### PR TITLE
Upgrade to `nightly-2022-11-16`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_version: nightly-2022-11-07
+  rust_version: nightly-2022-11-16
 
 jobs:
   fmt:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_version: nightly-2022-07-26
+  rust_version: nightly-2022-11-07
 
 jobs:
   fmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-check-external-types"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -360,9 +360,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.12.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a260c376ebec8b6fcd30f518b253772873c5dd8564b45e384aad8a79c62aa6"
+checksum = "7745b68b43d89a088d2d270be09f54f948e587fc540cb15e3d3b75cb327a01c3"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-check-external-types"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Static analysis tool to detect external types exposed in a library's public API."
 edition = "2021"
@@ -13,7 +13,7 @@ cargo_metadata = "0.15"
 clap = { version = "~3.2.23", features = ["derive"] }
 owo-colors = { version = "3", features = ["supports-colors"] }
 pest = "2" # For pretty error formatting
-rustdoc-types = "0.12"
+rustdoc-types = "0.18"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.5"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ How to Use
 
 _Important:_ This tool requires a nightly build of Rust to be installed since it relies on
 the [rustdoc JSON output](https://github.com/rust-lang/rust/issues/76578), which hasn't been
-stabilized yet. It was last tested against `nightly-2022-11-07`.
+stabilized yet. It was last tested against `nightly-2022-11-16`.
 
 To install, run the following from this README path:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ How to Use
 
 _Important:_ This tool requires a nightly build of Rust to be installed since it relies on
 the [rustdoc JSON output](https://github.com/rust-lang/rust/issues/76578), which hasn't been
-stabilized yet. It was last tested against `nightly-2022-07-25`.
+stabilized yet. It was last tested against `nightly-2022-11-07`.
 
 To install, run the following from this README path:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-07-26"
+channel = "nightly-2022-11-07"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-11-07"
+channel = "nightly-2022-11-16"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -46,7 +46,7 @@ impl CargoRustDocJson {
     pub fn run(&self) -> Result<Crate> {
         let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
 
-        let mut command = Command::new(&cargo);
+        let mut command = Command::new(cargo);
         command.current_dir(&self.crate_path).arg("rustdoc");
         if !self.features.is_empty() {
             command.arg("--no-default-features").arg("--features");

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -67,7 +67,7 @@ impl CargoRustDocJson {
         let output_file_name = self
             .target_path
             .canonicalize()
-            .context(here!())?
+            .context(here!("failed to canonicalize {:?}", self.target_path))?
             .join(format!("doc/{}.json", self.crate_name.replace('-', "_")));
 
         let json = fs::read_to_string(output_file_name).context(here!())?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::NEW_ISSUE_URL;
 use anyhow::{Context, Result};
 use owo_colors::{OwoColorize, Stream};
 use pest::Position;
@@ -27,6 +28,7 @@ pub enum ErrorLocation {
     ClosureOutput,
     ConstGeneric,
     Constant,
+    DynTrait,
     EnumTupleEntry,
     GenericArg,
     GenericDefaultBinding,
@@ -51,6 +53,7 @@ impl fmt::Display for ErrorLocation {
             Self::ClosureOutput => "closure output of",
             Self::ConstGeneric => "const generic of",
             Self::Constant => "constant",
+            Self::DynTrait => "dyn trait of",
             Self::EnumTupleEntry => "enum tuple entry of",
             Self::GenericArg => "generic arg of",
             Self::GenericDefaultBinding => "generic default binding of",
@@ -94,6 +97,12 @@ impl ValidationError {
             "{}:{type_name}:{what}:{in_what_type}",
             location_sort_key(location)
         );
+        if location.is_none() {
+            eprintln!(
+                "WARN: An error is missing a span and will be printed without context, file name, and line number. \
+                This is a bug. Please report it with a piece of Rust code that triggers it at: {NEW_ISSUE_URL}"
+            );
+        }
         Self::UnapprovedExternalTypeRef {
             type_name,
             what: what.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pub(crate) const NEW_ISSUE_URL: &str =
+    "https://github.com/awslabs/cargo-check-external-types/issues/new";
+
 pub mod cargo;
 pub mod config;
 pub mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@ macro_rules! here {
     () => {
         concat!("error at ", file!(), ":", line!(), ":", column!())
     };
-    ($message:tt) => {
-        concat!($message, " (", here!(), ")")
+    ($($args:tt)+) => {
+        format!("{} ({})", format!($($args)+), here!())
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,3 +23,29 @@ macro_rules! here {
         concat!($message, " (", here!(), ")")
     };
 }
+
+/// Macro that indicates there is a bug in the program, but doesn't panic.
+#[macro_export]
+macro_rules! bug {
+    ($($args:tt)+) => {
+        {
+            use owo_colors::{OwoColorize, Stream};
+            eprint!("{}",
+                "BUG: "
+                    .if_supports_color(Stream::Stdout, |text| text.purple())
+                    .if_supports_color(Stream::Stdout, |text| text.bold())
+            );
+            eprint!($($args)+);
+            eprintln!(" This is a bug. Please report it with a piece of Rust code that triggers it at: {}", $crate::NEW_ISSUE_URL);
+        }
+    };
+}
+
+/// Macro that indicates there is a bug in the program and then panics.
+#[macro_export]
+macro_rules! bug_panic {
+    ($($args:tt)+) => {
+        $crate::bug!($($args)+);
+        panic!("execution cannot continue");
+    };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,7 +175,7 @@ fn run_main() -> Result<(), Error> {
     match args.output_format {
         OutputFormat::Errors => {
             ErrorPrinter::new(&cargo_metadata.workspace_root).pretty_print_errors(&errors);
-            if !errors.is_empty() {
+            if errors.error_count() > 0 {
                 return Err(Error::ValidationErrors);
             }
         }
@@ -183,7 +183,7 @@ fn run_main() -> Result<(), Error> {
             println!("| Crate | Type | Used In |");
             println!("| ---   | ---  | ---     |");
             let mut rows = Vec::new();
-            for error in &errors {
+            for error in errors.iter() {
                 if let ValidationError::UnapprovedExternalTypeRef { .. } = error {
                     let type_name = error.type_name();
                     let crate_name = &type_name[0..type_name.find("::").unwrap_or(type_name.len())];

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,11 @@
 use anyhow::{anyhow, bail};
 use anyhow::{Context, Result};
 use cargo_check_external_types::cargo::CargoRustDocJson;
-use cargo_check_external_types::error::ErrorPrinter;
+use cargo_check_external_types::error::{ErrorPrinter, ValidationError};
 use cargo_check_external_types::here;
 use cargo_check_external_types::visitor::Visitor;
 use cargo_metadata::{CargoOpt, Metadata};
 use clap::Parser;
-use owo_colors::{OwoColorize, Stream};
 use std::borrow::Cow;
 use std::fmt;
 use std::fs;
@@ -175,19 +174,8 @@ fn run_main() -> Result<(), Error> {
     let errors = Visitor::new(config, package)?.visit_all()?;
     match args.output_format {
         OutputFormat::Errors => {
-            let mut error_printer = ErrorPrinter::new(&cargo_metadata.workspace_root);
-            for error in &errors {
-                println!("{}", error);
-                if let Some(location) = error.location() {
-                    error_printer.pretty_print_error_context(location, error.subtext())
-                }
-            }
+            ErrorPrinter::new(&cargo_metadata.workspace_root).pretty_print_errors(&errors);
             if !errors.is_empty() {
-                println!(
-                    "{} {} emitted",
-                    errors.len(),
-                    "errors".if_supports_color(Stream::Stdout, |text| text.red())
-                );
                 return Err(Error::ValidationErrors);
             }
         }
@@ -196,17 +184,19 @@ fn run_main() -> Result<(), Error> {
             println!("| ---   | ---  | ---     |");
             let mut rows = Vec::new();
             for error in &errors {
-                let type_name = error.type_name();
-                let crate_name = &type_name[0..type_name.find("::").unwrap_or(type_name.len())];
-                let location = error.location().unwrap();
-                rows.push(format!(
-                    "| {} | {} | {}:{}:{} |",
-                    crate_name,
-                    type_name,
-                    location.filename.to_string_lossy(),
-                    location.begin.0,
-                    location.begin.1
-                ));
+                if let ValidationError::UnapprovedExternalTypeRef { .. } = error {
+                    let type_name = error.type_name();
+                    let crate_name = &type_name[0..type_name.find("::").unwrap_or(type_name.len())];
+                    let location = error.location().unwrap();
+                    rows.push(format!(
+                        "| {} | {} | {}:{}:{} |",
+                        crate_name,
+                        type_name,
+                        location.filename.to_string_lossy(),
+                        location.begin.0,
+                        location.begin.1
+                    ));
+                }
             }
             rows.sort();
             rows.into_iter().for_each(|row| println!("{}", row));

--- a/src/path.rs
+++ b/src/path.rs
@@ -16,6 +16,7 @@ pub enum ComponentType {
     Enum,
     EnumVariant,
     Function,
+    Impl,
     Method,
     Module,
     ReExport,
@@ -86,6 +87,7 @@ impl fmt::Display for Path {
         let names: Vec<&str> = self
             .stack
             .iter()
+            .filter(|component| !component.name.is_empty())
             .map(|component| component.name.as_str())
             .collect();
         write!(f, "{}", names.join("::"))

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -7,11 +7,12 @@ use crate::config::Config;
 use crate::error::{ErrorLocation, ValidationError};
 use crate::here;
 use crate::path::{ComponentType, Path};
+use crate::NEW_ISSUE_URL;
 use anyhow::{anyhow, Context, Result};
 use rustdoc_types::{
     Crate, FnDecl, GenericArgs, GenericBound, GenericParamDef, GenericParamDefKind, Generics, Id,
-    Item, ItemEnum, ItemSummary, Struct, Term, Trait, Type, Union, Variant, Visibility,
-    WherePredicate,
+    Item, ItemEnum, ItemSummary, Path as RustDocPath, Struct, StructKind, Term, Trait, Type, Union,
+    Variant, Visibility, WherePredicate,
 };
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap};
@@ -153,9 +154,7 @@ impl Visitor {
             ItemEnum::Enum(enm) => {
                 path.push(ComponentType::Enum, item);
                 self.visit_generics(&path, &enm.generics).context(here!())?;
-                for id in &enm.impls {
-                    self.visit_impl(&path, self.item(id).context(here!())?)?;
-                }
+                self.visit_impls(&path, &enm.impls).context(here!())?;
                 for id in &enm.variants {
                     self.visit_item(&path, self.item(id).context(here!())?, VisibilityCheck::Default).context(here!())?;
                 }
@@ -247,8 +246,22 @@ impl Visitor {
             ItemEnum::ExternCrate { .. }
             | ItemEnum::Impl(_)
             | ItemEnum::Macro(_)
-            | ItemEnum::PrimitiveType(_)
+            | ItemEnum::Primitive(_)
             | ItemEnum::ProcMacro(_) => {}
+        }
+        Ok(())
+    }
+
+    fn visit_impls(&self, path: &Path, impl_ids: &[Id]) -> Result<()> {
+        for id in impl_ids {
+            let impl_item = self.item(id).context(here!())?;
+            let mut impl_path = path.clone();
+            impl_path.push_raw(
+                ComponentType::Impl,
+                "",
+                impl_item.span.as_ref().or_else(|| path.last_span()),
+            );
+            self.visit_impl(&impl_path, impl_item).context(here!())?;
         }
         Ok(())
     }
@@ -256,13 +269,25 @@ impl Visitor {
     #[instrument(level = "debug", skip(self, path, strct), fields(path = %path))]
     fn visit_struct(&self, path: &Path, strct: &Struct) -> Result<()> {
         self.visit_generics(path, &strct.generics)?;
-        for id in &strct.fields {
+        let field_ids = match &strct.kind {
+            StructKind::Unit => {
+                // Unit structs don't have fields
+                Vec::new()
+            }
+            StructKind::Tuple(members) => members.iter().flatten().cloned().collect(),
+            StructKind::Plain {
+                fields,
+                fields_stripped,
+            } => {
+                assert!(!fields_stripped, "rustdoc is instructed to document private items, so `fields_stripped` should always be `false`");
+                fields.clone()
+            }
+        };
+        for id in &field_ids {
             let field = self.item(id).context(here!())?;
             self.visit_item(path, field, VisibilityCheck::Default)?;
         }
-        for id in &strct.impls {
-            self.visit_impl(path, self.item(id).context(here!())?)?;
-        }
+        self.visit_impls(path, &strct.impls).context(here!())?;
         Ok(())
     }
 
@@ -273,9 +298,7 @@ impl Visitor {
             let field = self.item(id).context(here!())?;
             self.visit_item(path, field, VisibilityCheck::Default)?;
         }
-        for id in &unn.impls {
-            self.visit_impl(path, self.item(id).context(here!())?)?;
-        }
+        self.visit_impls(path, &unn.impls).context(here!())?;
         Ok(())
     }
 
@@ -290,6 +313,7 @@ impl Visitor {
         Ok(())
     }
 
+    /// Visits an `impl` block
     #[instrument(level = "debug", skip(self, path, item), fields(path = %path, id = %item.id.0))]
     fn visit_impl(&self, path: &Path, item: &Item) -> Result<()> {
         if let ItemEnum::Impl(imp) = &item.inner {
@@ -297,17 +321,24 @@ impl Visitor {
             if imp.blanket_impl.is_some() {
                 return Ok(());
             }
+            // Does the `impl` implement a trait?
             if let Some(trait_) = &imp.trait_ {
-                if let Type::ResolvedPath { id, .. } = trait_ {
-                    let trait_item = self.item(id).context(here!())?;
+                let trait_item = self.item(&trait_.id).context(here!())?;
 
-                    // Don't look for exposure in impls of private traits
-                    if !Self::is_public(path, trait_item) {
-                        return Ok(());
-                    }
+                // Don't look for exposure in impls of private traits
+                if !Self::is_public(path, trait_item) {
+                    return Ok(());
                 }
 
-                self.visit_type(path, &ErrorLocation::ImplementedTrait, trait_)
+                if let Some(_generic_args) = &trait_.args {
+                    // The `trait_` can have generic `args`, but we don't need to visit them
+                    // since they are on the trait itself. If the trait is part of the root crate,
+                    // it will be visited and checked for external types. If the trait is external,
+                    // then what it references doesn't matter for the purposes of this impl that is
+                    // being visited.
+                }
+
+                self.check_rustdoc_path(path, &ErrorLocation::ImplementedTrait, trait_)
                     .context(here!())?;
             }
 
@@ -344,17 +375,12 @@ impl Visitor {
     #[instrument(level = "debug", skip(self, path, typ), fields(path = %path))]
     fn visit_type(&self, path: &Path, what: &ErrorLocation, typ: &Type) -> Result<()> {
         match typ {
-            Type::ResolvedPath {
-                id,
-                args,
-                param_names,
-                ..
-            } => {
-                self.check_external(path, what, id).context(here!())?;
-                if let Some(args) = args {
-                    self.visit_generic_args(path, args)?;
+            Type::ResolvedPath(resolved_path) => {
+                self.check_rustdoc_path(path, what, resolved_path)
+                    .context(here!())?;
+                if let Some(args) = &resolved_path.args {
+                    self.visit_generic_args(path, args.as_ref())?;
                 }
-                self.visit_generic_bounds(path, param_names)?;
             }
             Type::Generic(_) => {}
             Type::Primitive(_) => {}
@@ -369,6 +395,14 @@ impl Visitor {
             }
             Type::Slice(typ) => self.visit_type(path, what, typ).context(here!())?,
             Type::Array { type_, .. } => self.visit_type(path, what, type_).context(here!())?,
+            Type::DynTrait(dyn_trait) => {
+                for trait_ in &dyn_trait.traits {
+                    self.check_rustdoc_path(path, &ErrorLocation::DynTrait, &trait_.trait_)
+                        .context(here!())?;
+                    self.visit_generic_param_defs(path, &trait_.generic_params)
+                        .context(here!())?;
+                }
+            }
             Type::ImplTrait(impl_trait) => {
                 for bound in impl_trait {
                     match bound {
@@ -377,7 +411,7 @@ impl Visitor {
                             generic_params,
                             ..
                         } => {
-                            self.visit_type(path, what, trait_)?;
+                            self.check_rustdoc_path(path, what, trait_)?;
                             self.visit_generic_param_defs(path, generic_params)?;
                         }
                         GenericBound::Outlives(_) => {}
@@ -387,9 +421,8 @@ impl Visitor {
             Type::Infer => {
                 // Don't know what Rust code translates into `Type::Infer`
                 unimplemented!(
-                    "This is a bug (visit_type for Type::Infer). \
-                    If you encounter this, please report it with the piece of Rust code that triggers it: \
-                    https://github.com/awslabs/cargo-check-external-types/issues/new"
+                    "This is a bug (visit_type for Type::Infer). If you encounter this,
+                    please report it with the piece of Rust code that triggers it: {NEW_ISSUE_URL}"
                 )
             }
             Type::RawPointer { type_, .. } => {
@@ -402,7 +435,7 @@ impl Visitor {
                 self_type, trait_, ..
             } => {
                 self.visit_type(path, &ErrorLocation::QualifiedSelfType, self_type)?;
-                self.visit_type(path, &ErrorLocation::QualifiedSelfTypeAsTrait, trait_)?;
+                self.check_rustdoc_path(path, &ErrorLocation::QualifiedSelfTypeAsTrait, trait_)?;
             }
         }
         Ok(())
@@ -459,7 +492,7 @@ impl Visitor {
                 ..
             } = bound
             {
-                self.visit_type(path, &ErrorLocation::TraitBound, trait_)
+                self.check_rustdoc_path(path, &ErrorLocation::TraitBound, trait_)
                     .context(here!())?;
                 self.visit_generic_param_defs(path, generic_params)?;
             }
@@ -486,7 +519,9 @@ impl Visitor {
                     self.visit_type(path, &ErrorLocation::ConstGeneric, type_)
                         .context(here!())?;
                 }
-                _ => {}
+                GenericParamDefKind::Lifetime { .. } => {
+                    // Lifetimes don't have types to check
+                }
             }
         }
         Ok(())
@@ -522,14 +557,22 @@ impl Visitor {
     #[instrument(level = "debug", skip(self, path, variant), fields(path = %path))]
     fn visit_variant(&self, path: &Path, variant: &Variant) -> Result<()> {
         match variant {
-            Variant::Plain => {}
+            Variant::Plain(_) => {}
             Variant::Tuple(types) => {
-                for typ in types {
-                    self.visit_type(path, &ErrorLocation::EnumTupleEntry, typ)?;
+                for type_id in types.iter().flatten() {
+                    // The type ID isn't the ID of the type being referenced, but rather, the ID
+                    // of the tuple entry (for example `0` or `1`). The actual type needs to be further
+                    // probed out of this (hence calling `visit_item` instead of `check_external`).
+                    let tuple_entry_item = self.item(type_id).context(here!())?;
+                    self.visit_item(path, tuple_entry_item, VisibilityCheck::Default)?;
                 }
             }
-            Variant::Struct(ids) => {
-                for id in ids {
+            Variant::Struct {
+                fields,
+                fields_stripped,
+            } => {
+                assert!(!fields_stripped, "rustdoc is instructed to document private items, so `fields_stripped` should always be `false`");
+                for id in fields {
                     self.visit_item(
                         path,
                         self.item(id).context(here!())?,
@@ -541,11 +584,27 @@ impl Visitor {
         Ok(())
     }
 
+    #[instrument(level = "debug", skip(self, path, rustdoc_path), fields(path = %path))]
+    fn check_rustdoc_path(
+        &self,
+        path: &Path,
+        what: &ErrorLocation,
+        rustdoc_path: &RustDocPath,
+    ) -> Result<()> {
+        self.check_external(path, what, &rustdoc_path.id)
+            .context(here!())?;
+        if let Some(generic_args) = &rustdoc_path.args {
+            self.visit_generic_args(path, generic_args.as_ref())
+                .context(here!())?;
+        }
+        Ok(())
+    }
+
     fn check_external(&self, path: &Path, what: &ErrorLocation, id: &Id) -> Result<()> {
         if let Ok(type_name) = self.type_name(id) {
             if !self.config.allows_type(&self.root_crate_name, &type_name) {
                 self.add_error(ValidationError::unapproved_external_type_ref(
-                    self.type_name(id)?,
+                    type_name,
                     what,
                     path.to_string(),
                     path.last_span(),

--- a/test-workspace/test-crate/src/lib.rs
+++ b/test-workspace/test-crate/src/lib.rs
@@ -10,6 +10,7 @@
 //! exposure of external types in a public API.
 
 pub mod test_assoc_type;
+pub mod test_fields_stripped;
 pub mod test_structs;
 pub mod test_union;
 
@@ -19,7 +20,6 @@ use external_lib::{
     SimpleTrait,
     SomeOtherStruct,
     SomeStruct,
-    // Remove this comment if more lines are needed for imports in the future to preserve line numbers
     // Remove this comment if more lines are needed for imports in the future to preserve line numbers
     // Remove this comment if more lines are needed for imports in the future to preserve line numbers
     // Remove this comment if more lines are needed for imports in the future to preserve line numbers

--- a/test-workspace/test-crate/src/lib.rs
+++ b/test-workspace/test-crate/src/lib.rs
@@ -10,6 +10,7 @@
 //! exposure of external types in a public API.
 
 pub mod test_assoc_type;
+pub mod test_structs;
 pub mod test_union;
 
 use external_lib::{
@@ -18,7 +19,6 @@ use external_lib::{
     SimpleTrait,
     SomeOtherStruct,
     SomeStruct,
-    // Remove this comment if more lines are needed for imports in the future to preserve line numbers
     // Remove this comment if more lines are needed for imports in the future to preserve line numbers
     // Remove this comment if more lines are needed for imports in the future to preserve line numbers
     // Remove this comment if more lines are needed for imports in the future to preserve line numbers

--- a/test-workspace/test-crate/src/test_fields_stripped.rs
+++ b/test-workspace/test-crate/src/test_fields_stripped.rs
@@ -1,0 +1,11 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Stripped fields are any public fields marked as `#[doc(hidden)]`
+pub struct SomeStructWithStrippedFields {
+    pub public_field: i32,
+    #[doc(hidden)]
+    pub stripped_field: u32,
+}

--- a/test-workspace/test-crate/src/test_structs.rs
+++ b/test-workspace/test-crate/src/test_structs.rs
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+pub struct LocalUnitStruct;
+
+pub struct TupleStructWithExternalType(pub external_lib::SomeStruct);
+pub struct TupleStructWithoutExternalType(pub LocalUnitStruct);
+pub struct TupleStructWithPrivateExternalType(external_lib::SomeStruct);
+pub struct TupleStructWithoutPrivateExternalType(LocalUnitStruct);
+
+pub struct PlainStructWithExternalType {
+    pub external: external_lib::SomeStruct,
+}
+pub struct PlainStructWithoutExternalType {
+    pub not_external: LocalUnitStruct,
+}
+pub struct PlainStructWithPrivateExternalType {
+    external: external_lib::SomeStruct,
+}
+pub struct PlainStructWithoutPrivateExternalType {
+    not_external: LocalUnitStruct,
+}
+
+pub struct ImplsGenericTrait;
+impl external_lib::SimpleGenericTrait<external_lib::SomeStruct> for ImplsGenericTrait {
+    fn something(&self, thing: external_lib::SomeStruct) -> u32 {
+        0
+    }
+}

--- a/tests/allow-some-types-expected-output.txt
+++ b/tests/allow-some-types-expected-output.txt
@@ -36,4 +36,5 @@ error: Unapproved external type `external_lib::ReprCType` referenced in public A
    |
    = in return value of `test_crate::test_union::SimpleUnion::repr_c`
 
-4 errors emitted
+warning: Fields on `test_crate::test_fields_stripped::SomeStructWithStrippedFields` marked `#[doc(hidden)]` cannot be checked for external types
+4 errors, 1 warnings emitted

--- a/tests/default-config-expected-output.txt
+++ b/tests/default-config-expected-output.txt
@@ -418,4 +418,5 @@ error: Unapproved external type `external_lib::SimpleTrait` referenced in public
    |
    = in trait bound of `test_crate::test_union::GenericUnion`
 
-48 errors emitted
+warning: Fields on `test_crate::test_fields_stripped::SomeStructWithStrippedFields` marked `#[doc(hidden)]` cannot be checked for external types
+48 errors, 1 warnings emitted

--- a/tests/default-config-expected-output.txt
+++ b/tests/default-config-expected-output.txt
@@ -138,21 +138,21 @@ error: Unapproved external type `external_lib::SomeStruct` referenced in public 
    |
    = in generic default binding of `test_crate::EnumWithExternals`
 
-error: Unapproved external type `external_lib::SimpleTrait` referenced in public API
-  --> test-crate/src/lib.rs:89:5
-   |
-89 |     TupleEnum(SomeStruct, Box<dyn SimpleTrait>),
-   |     ^-----------------------------------------^
-   |
-   = in generic arg of `test_crate::EnumWithExternals::TupleEnum`
-
 error: Unapproved external type `external_lib::SomeStruct` referenced in public API
-  --> test-crate/src/lib.rs:89:5
+  --> test-crate/src/lib.rs:89:15
    |
 89 |     TupleEnum(SomeStruct, Box<dyn SimpleTrait>),
-   |     ^-----------------------------------------^
+   |               ^--------^
    |
-   = in enum tuple entry of `test_crate::EnumWithExternals::TupleEnum`
+   = in struct field of `test_crate::EnumWithExternals::TupleEnum::0`
+
+error: Unapproved external type `external_lib::SimpleTrait` referenced in public API
+  --> test-crate/src/lib.rs:89:27
+   |
+89 |     TupleEnum(SomeStruct, Box<dyn SimpleTrait>),
+   |                           ^------------------^
+   |
+   = in dyn trait of `test_crate::EnumWithExternals::TupleEnum::1`
 
 error: Unapproved external type `external_lib::SomeStruct` referenced in public API
   --> test-crate/src/lib.rs:91:9
@@ -168,7 +168,7 @@ error: Unapproved external type `external_lib::SimpleTrait` referenced in public
 92 |         simple_trait: Box<dyn SimpleTrait>,
    |         ^--------------------------------^
    |
-   = in generic arg of `test_crate::EnumWithExternals::StructEnum::simple_trait`
+   = in dyn trait of `test_crate::EnumWithExternals::StructEnum::simple_trait`
 
 error: Unapproved external type `external_lib::SimpleTrait` referenced in public API
    --> test-crate/src/lib.rs:104:5
@@ -234,7 +234,7 @@ error: Unapproved external type `external_lib::SimpleTrait` referenced in public
 122 | pub type DynExternalReferencingTypedef = Box<dyn SimpleTrait>;
     | ^------------------------------------------------------------^
     |
-    = in generic arg of `test_crate::DynExternalReferencingTypedef`
+    = in dyn trait of `test_crate::DynExternalReferencingTypedef`
 
 error: Unapproved external type `external_lib::SomeStruct` referenced in public API
    --> test-crate/src/lib.rs:123:1
@@ -354,6 +354,42 @@ error: Unapproved external type `external_lib::SomeStruct` referenced in public 
    |
    = in generic arg of `test_crate::test_assoc_type::PublicStructImplsPublicTraitWithAssocType::Something`
 
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+ --> test-crate/src/test_structs.rs:8:40
+  |
+8 | pub struct TupleStructWithExternalType(pub external_lib::SomeStruct);
+  |                                        ^--------------------------^
+  |
+  = in struct field of `test_crate::test_structs::TupleStructWithExternalType::0`
+
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-crate/src/test_structs.rs:14:5
+   |
+14 |     pub external: external_lib::SomeStruct,
+   |     ^------------------------------------^
+   |
+   = in struct field of `test_crate::test_structs::PlainStructWithExternalType::external`
+
+error: Unapproved external type `external_lib::SimpleGenericTrait` referenced in public API
+  --> test-crate/src/test_structs.rs:27:1
+   |
+27 | impl external_lib::SimpleGenericTrait<external_lib::SomeStruct> for ImplsGenericTrait {
+   | ...
+31 | }␊
+   | ^
+   |
+   = in implemented trait of `test_crate::test_structs::ImplsGenericTrait`
+
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-crate/src/test_structs.rs:27:1
+   |
+27 | impl external_lib::SimpleGenericTrait<external_lib::SomeStruct> for ImplsGenericTrait {
+   | ...
+31 | }␊
+   | ^
+   |
+   = in generic arg of `test_crate::test_structs::ImplsGenericTrait`
+
 error: Unapproved external type `external_lib::ReprCType` referenced in public API
   --> test-crate/src/test_union.rs:10:5
    |
@@ -382,4 +418,4 @@ error: Unapproved external type `external_lib::SimpleTrait` referenced in public
    |
    = in trait bound of `test_crate::test_union::GenericUnion`
 
-44 errors emitted
+48 errors emitted

--- a/tests/output-format-markdown-table-expected-output.md
+++ b/tests/output-format-markdown-table-expected-output.md
@@ -4,6 +4,7 @@
 | external_lib | external_lib::AssociatedGenericTrait | test-crate/src/lib.rs:136:4 |
 | external_lib | external_lib::ReprCType | test-crate/src/test_union.rs:10:4 |
 | external_lib | external_lib::ReprCType | test-crate/src/test_union.rs:15:4 |
+| external_lib | external_lib::SimpleGenericTrait | test-crate/src/test_structs.rs:27:0 |
 | external_lib | external_lib::SimpleNewType | test-crate/src/lib.rs:158:4 |
 | external_lib | external_lib::SimpleTrait | test-crate/src/lib.rs:104:4 |
 | external_lib | external_lib::SimpleTrait | test-crate/src/lib.rs:122:0 |
@@ -13,7 +14,7 @@
 | external_lib | external_lib::SimpleTrait | test-crate/src/lib.rs:38:0 |
 | external_lib | external_lib::SimpleTrait | test-crate/src/lib.rs:38:0 |
 | external_lib | external_lib::SimpleTrait | test-crate/src/lib.rs:47:0 |
-| external_lib | external_lib::SimpleTrait | test-crate/src/lib.rs:89:4 |
+| external_lib | external_lib::SimpleTrait | test-crate/src/lib.rs:89:26 |
 | external_lib | external_lib::SimpleTrait | test-crate/src/lib.rs:92:8 |
 | external_lib | external_lib::SimpleTrait | test-crate/src/test_union.rs:21:0 |
 | external_lib | external_lib::SomeOtherStruct | test-crate/src/lib.rs:125:0 |
@@ -40,7 +41,10 @@
 | external_lib | external_lib::SomeStruct | test-crate/src/lib.rs:80:4 |
 | external_lib | external_lib::SomeStruct | test-crate/src/lib.rs:81:4 |
 | external_lib | external_lib::SomeStruct | test-crate/src/lib.rs:84:0 |
-| external_lib | external_lib::SomeStruct | test-crate/src/lib.rs:89:4 |
+| external_lib | external_lib::SomeStruct | test-crate/src/lib.rs:89:14 |
 | external_lib | external_lib::SomeStruct | test-crate/src/lib.rs:91:8 |
 | external_lib | external_lib::SomeStruct | test-crate/src/test_assoc_type.rs:12:4 |
 | external_lib | external_lib::SomeStruct | test-crate/src/test_assoc_type.rs:55:4 |
+| external_lib | external_lib::SomeStruct | test-crate/src/test_structs.rs:14:4 |
+| external_lib | external_lib::SomeStruct | test-crate/src/test_structs.rs:27:0 |
+| external_lib | external_lib::SomeStruct | test-crate/src/test_structs.rs:8:39 |

--- a/tests/test-reexports-expected-output.md
+++ b/tests/test-reexports-expected-output.md
@@ -54,4 +54,4 @@ error: Unapproved external type `external_lib::SomeStruct` referenced in public 
    |
    = in re-export named `test_reexports_crate::SomeStruct`
 
-7 errors emitted
+7 errors, 0 warnings emitted


### PR DESCRIPTION
This PR upgrades the nightly compiler that `cargo-check-external-types` is compatible with to `nightly-2022-11-16`.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
