### PR TITLE
Make compatible with current nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_version: nightly-2023-05-31
+  rust_version: nightly-2023-10-10
 
 jobs:
   fmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,9 +367,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7a12c7506980eaac5c9851a04e90e0062eb4417aa188a512bf7a64a1ef290f"
+checksum = "cc646f09069d689083b975698bdac4edb96c2f0e7d270b701760814b886bb224"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ cargo_metadata = "0.15"
 clap = { version = "~3.2.25", features = ["derive"] }
 owo-colors = { version = "3", features = ["supports-colors"] }
 pest = "2" # For pretty error formatting
-rustdoc-types = "0.22.0"
+rustdoc-types = "0.23.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.7"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ How to Use
 
 _Important:_ This tool requires a nightly build of Rust to be installed since it relies on
 the [rustdoc JSON output](https://github.com/rust-lang/rust/issues/76578), which hasn't been
-stabilized yet. It was last tested against `nightly-2023-05-31`.
+stabilized yet. It was last tested against `nightly-2023-10-10`.
 
 To install, run the following from this README path:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-05-31"
+channel = "nightly-2023-10-10"

--- a/src/error.rs
+++ b/src/error.rs
@@ -279,13 +279,13 @@ fn location_sort_key(location: Option<&Span>) -> String {
 
 impl Ord for ValidationError {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        self.sort_key().cmp(other.sort_key())
     }
 }
 
 impl PartialOrd for ValidationError {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.sort_key().partial_cmp(other.sort_key())
+        Some(self.cmp(other))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,7 +42,7 @@ pub enum ErrorLocation {
     Static,
     StructField,
     TraitBound,
-    TypeDef,
+    TypeAlias,
     WhereBound,
 }
 
@@ -67,7 +67,7 @@ impl fmt::Display for ErrorLocation {
             Self::Static => "static value",
             Self::StructField => "struct field of",
             Self::TraitBound => "trait bound of",
-            Self::TypeDef => "typedef type of",
+            Self::TypeAlias => "type alias of",
             Self::WhereBound => "where bound of",
         };
         write!(f, "{}", s)

--- a/src/path.rs
+++ b/src/path.rs
@@ -23,7 +23,7 @@ pub enum ComponentType {
     Struct,
     StructField,
     Trait,
-    TypeDef,
+    TypeAlias,
     Union,
 }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -242,11 +242,11 @@ impl Visitor {
                 path.push(ComponentType::Trait, item);
                 self.visit_trait(&path, trt).context(here!())?;
             }
-            ItemEnum::Typedef(typedef) => {
-                path.push(ComponentType::TypeDef, item);
-                self.visit_type(&path, &ErrorLocation::TypeDef, &typedef.type_)
+            ItemEnum::TypeAlias(alias) => {
+                path.push(ComponentType::TypeAlias, item);
+                self.visit_type(&path, &ErrorLocation::TypeAlias, &alias.type_)
                     .context(here!())?;
-                self.visit_generics(&path, &typedef.generics).context(here!())?;
+                self.visit_generics(&path, &alias.generics).context(here!())?;
             }
             ItemEnum::TraitAlias(_) => unstable_rust_feature!(
                 "trait_alias",

--- a/test-workspace/test-crate/src/lib.rs
+++ b/test-workspace/test-crate/src/lib.rs
@@ -117,9 +117,9 @@ pub mod some_pub_mod {
 }
 
 pub type NotExternalReferencing = u32;
-pub type ExternalReferencingTypedef = SomeStruct;
-pub type OptionalExternalReferencingTypedef = Option<SomeStruct>;
-pub type DynExternalReferencingTypedef = Box<dyn SimpleTrait>;
+pub type ExternalReferencingTypeAlias = SomeStruct;
+pub type OptionalExternalReferencingTypeAlias = Option<SomeStruct>;
+pub type DynExternalReferencingTypeAlias = Box<dyn SimpleTrait>;
 pub type ExternalReferencingRawPtr = *const SomeStruct;
 
 pub fn fn_with_external_trait_bounds<I, O, E, T>(_thing: T)

--- a/tests/default-config-expected-output.md
+++ b/tests/default-config-expected-output.md
@@ -215,26 +215,26 @@ error: Unapproved external type `external_lib::SomeStruct` referenced in public 
 error: Unapproved external type `external_lib::SomeStruct` referenced in public API
    --> test-crate/src/lib.rs:120:1
     |
-120 | pub type ExternalReferencingTypedef = SomeStruct;
-    | ^-----------------------------------------------^
+120 | pub type ExternalReferencingTypeAlias = SomeStruct;
+    | ^-------------------------------------------------^
     |
-    = in typedef type of `test_crate::ExternalReferencingTypedef`
+    = in type alias of `test_crate::ExternalReferencingTypeAlias`
 
 error: Unapproved external type `external_lib::SomeStruct` referenced in public API
    --> test-crate/src/lib.rs:121:1
     |
-121 | pub type OptionalExternalReferencingTypedef = Option<SomeStruct>;
-    | ^---------------------------------------------------------------^
+121 | pub type OptionalExternalReferencingTypeAlias = Option<SomeStruct>;
+    | ^-----------------------------------------------------------------^
     |
-    = in generic arg of `test_crate::OptionalExternalReferencingTypedef`
+    = in generic arg of `test_crate::OptionalExternalReferencingTypeAlias`
 
 error: Unapproved external type `external_lib::SimpleTrait` referenced in public API
    --> test-crate/src/lib.rs:122:1
     |
-122 | pub type DynExternalReferencingTypedef = Box<dyn SimpleTrait>;
-    | ^------------------------------------------------------------^
+122 | pub type DynExternalReferencingTypeAlias = Box<dyn SimpleTrait>;
+    | ^--------------------------------------------------------------^
     |
-    = in dyn trait of `test_crate::DynExternalReferencingTypedef`
+    = in dyn trait of `test_crate::DynExternalReferencingTypeAlias`
 
 error: Unapproved external type `external_lib::SomeStruct` referenced in public API
    --> test-crate/src/lib.rs:123:1
@@ -242,7 +242,7 @@ error: Unapproved external type `external_lib::SomeStruct` referenced in public 
 123 | pub type ExternalReferencingRawPtr = *const SomeStruct;
     | ^-----------------------------------------------------^
     |
-    = in typedef type of `test_crate::ExternalReferencingRawPtr`
+    = in type alias of `test_crate::ExternalReferencingRawPtr`
 
 error: Unapproved external type `external_lib::AssociatedGenericTrait` referenced in public API
    --> test-crate/src/lib.rs:125:1


### PR DESCRIPTION
*Description of changes:*
I learned about this tool today at eurorust -- this PR aims to make it compatible with current nightly.

Prior to this PR, the output is:
```
$ cargo install --locked cargo-check-external-types
(...)
$ cargo +nightly check-external-types --config external-types.toml
Running rustdoc to produce json doc output...
[/home/jpixton/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-check-external-types-0.1.7/src/main.rs:101] err = Error {
    context: "error at /home/jpixton/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-check-external-types-0.1.7/src/main.rs:171:14",
    source: "The version of rustdoc being used produces JSON format version 27, but this tool requires format version 26. This can happen if the locally installed version of rustdoc doesn't match the rustdoc JSON types from the `rustdoc-types` crate.\n\nIf this occurs with the latest Rust nightly and the latest version of this tool, then this is a bug, and the tool needs to be upgraded to the latest format version.\n\nOtherwise, you'll need to determine a Rust nightly version that matches this tool's supported format version (or vice versa).",
}
error at /home/jpixton/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-check-external-types-0.1.7/src/main.rs:171:14: The version of rustdoc being used produces JSON format version 27, but this tool requires format version 26. This can happen if the locally installed version of rustdoc doesn't match the rustdoc JSON types from the `rustdoc-types` crate.

If this occurs with the latest Rust nightly and the latest version of this tool, then this is a bug, and the tool needs to be upgraded to the latest format version.

Otherwise, you'll need to determine a Rust nightly version that matches this tool's supported format version (or vice versa).
```

When taking rustdoc-types 0.23 I took the liberty of tracking the naming change around type aliases. That changes the public interface of this tool in a minor way.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
