### PR TITLE
Support detecting root package lib name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+/.idea

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -18,8 +18,9 @@ struct CrateFormatVersion {
 
 /// Runs the `cargo rustdoc` command required to produce Rustdoc's JSON output with a nightly compiler.
 pub struct CargoRustDocJson {
-    /// Name of the crate (as specified in the Cargo.toml file)
-    crate_name: String,
+    /// Name of the lib target, by default this is the crate name but may be customized in the
+    /// `[lib]` section of the Cargo.toml file.
+    lib_name: String,
     /// Path of the crate to examine
     crate_path: PathBuf,
     /// Expected `target/` directory where the output will be
@@ -30,13 +31,13 @@ pub struct CargoRustDocJson {
 
 impl CargoRustDocJson {
     pub fn new(
-        crate_name: impl Into<String>,
+        lib_name: impl Into<String>,
         crate_path: impl Into<PathBuf>,
         target_path: impl Into<PathBuf>,
         features: Vec<String>,
     ) -> Self {
         CargoRustDocJson {
-            crate_name: crate_name.into(),
+            lib_name: lib_name.into(),
             crate_path: crate_path.into(),
             target_path: target_path.into(),
             features,
@@ -68,7 +69,7 @@ impl CargoRustDocJson {
             .target_path
             .canonicalize()
             .context(here!("failed to canonicalize {:?}", self.target_path))?
-            .join(format!("doc/{}.json", self.crate_name.replace('-', "_")));
+            .join(format!("doc/{}.json", self.lib_name.replace('-', "_")));
 
         let json = fs::read_to_string(output_file_name).context(here!())?;
         let format_version: CrateFormatVersion = serde_json::from_str(&json)

--- a/test-workspace/Cargo.toml
+++ b/test-workspace/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "external-lib",
     "test-crate",
+    "test-crate-custom-lib-name",
     "test-reexports-crate",
     "test-type-exported-from-hidden-module",
 ]

--- a/test-workspace/test-crate-custom-lib-name/Cargo.toml
+++ b/test-workspace/test-crate-custom-lib-name/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "test-crate-custom-lib-name"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+external-lib = { path = "../external-lib" }
+
+[lib]
+name = "custom_lib"

--- a/test-workspace/test-crate-custom-lib-name/src/lib.rs
+++ b/test-workspace/test-crate-custom-lib-name/src/lib.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#![feature(generic_associated_types)]
+#![allow(dead_code)]
+
+//! This crate is used to test cargo-check-external-types against a crate that
+//! defines a custom lib name. It only offers a subset of possible violations,
+//! see `test-crate` for a more complete example.
+
+use external_lib::{SimpleNewType, SomeStruct};
+
+pub static SOME_STRUCT: SomeStruct = SomeStruct;
+pub const SOME_CONST: SomeStruct = SomeStruct;
+
+pub mod some_pub_mod {
+    use external_lib::SomeStruct;
+
+    pub static OPTIONAL_STRUCT: Option<SomeStruct> = None;
+    pub const OPTIONAL_CONST: Option<SomeStruct> = None;
+}
+
+pub type NotExternalReferencing = u32;
+pub type ExternalReferencingTypeAlias = SomeStruct;
+pub type OptionalExternalReferencingTypeAlias = Option<SomeStruct>;
+pub type ExternalReferencingRawPtr = *const SomeStruct;
+
+pub struct AssocConstStruct;
+
+impl AssocConstStruct {
+    pub const SOME_CONST: u32 = 5;
+
+    pub const OTHER_CONST: SimpleNewType = SimpleNewType(5);
+}

--- a/tests/default-config-custom-lib-name-expected-output.md
+++ b/tests/default-config-custom-lib-name-expected-output.md
@@ -1,0 +1,65 @@
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-crate-custom-lib-name/src/lib.rs:15:1
+   |
+15 | pub static SOME_STRUCT: SomeStruct = SomeStruct;
+   | ^----------------------------------------------^
+   |
+   = in static value `custom_lib::SOME_STRUCT`
+
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-crate-custom-lib-name/src/lib.rs:16:1
+   |
+16 | pub const SOME_CONST: SomeStruct = SomeStruct;
+   | ^--------------------------------------------^
+   |
+   = in constant `custom_lib::SOME_CONST`
+
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-crate-custom-lib-name/src/lib.rs:21:5
+   |
+21 |     pub static OPTIONAL_STRUCT: Option<SomeStruct> = None;
+   |     ^----------------------------------------------------^
+   |
+   = in generic arg of `custom_lib::some_pub_mod::OPTIONAL_STRUCT`
+
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-crate-custom-lib-name/src/lib.rs:22:5
+   |
+22 |     pub const OPTIONAL_CONST: Option<SomeStruct> = None;
+   |     ^--------------------------------------------------^
+   |
+   = in generic arg of `custom_lib::some_pub_mod::OPTIONAL_CONST`
+
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-crate-custom-lib-name/src/lib.rs:26:1
+   |
+26 | pub type ExternalReferencingTypeAlias = SomeStruct;
+   | ^-------------------------------------------------^
+   |
+   = in type alias of `custom_lib::ExternalReferencingTypeAlias`
+
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-crate-custom-lib-name/src/lib.rs:27:1
+   |
+27 | pub type OptionalExternalReferencingTypeAlias = Option<SomeStruct>;
+   | ^-----------------------------------------------------------------^
+   |
+   = in generic arg of `custom_lib::OptionalExternalReferencingTypeAlias`
+
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-crate-custom-lib-name/src/lib.rs:28:1
+   |
+28 | pub type ExternalReferencingRawPtr = *const SomeStruct;
+   | ^-----------------------------------------------------^
+   |
+   = in type alias of `custom_lib::ExternalReferencingRawPtr`
+
+error: Unapproved external type `external_lib::SimpleNewType` referenced in public API
+  --> test-crate-custom-lib-name/src/lib.rs:35:5
+   |
+35 |     pub const OTHER_CONST: SimpleNewType = SimpleNewType(5);
+   |     ^------------------------------------------------------^
+   |
+   = in struct field of `custom_lib::AssocConstStruct::OTHER_CONST`
+
+8 errors, 0 warnings emitted

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -44,6 +44,14 @@ fn with_default_config() {
 }
 
 #[test]
+fn with_custom_lib_name() {
+    let expected_output =
+        fs::read_to_string("tests/default-config-custom-lib-name-expected-output.md").unwrap();
+    let actual_output = run_with_args("test-workspace/test-crate-custom-lib-name", &[]);
+    assert_str_eq!(expected_output, actual_output);
+}
+
+#[test]
 fn with_some_allowed_types() {
     let expected_output = fs::read_to_string("tests/allow-some-types-expected-output.md").unwrap();
     let actual_output = run_with_args(


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/cargo-check-external-types/issues/113

*Description of changes:* Support detecting root package lib name.

Prior to this branch the crate name was unconditionally used as the JSON file name `CargoRustDocJson` would expect to be produced by running `rustdoc`. In some cases the package under test may specify an alternative `lib.name` in its `Cargo.toml`, which would result in a file not found error when using the crate name instead of that alternative name.

This branch updates the processing logic so that:

1. We use the cargo metadata to find the root package.
2. We iterate the root package looking for all `lib` type targets.
  i. If there is only one lib target, we extract its name to use for the `CargoRustDocJson` expected filename.
  ii. If there is more than one lib target, we return an error - this shouldn't be possible based on today's `Cargo.toml` semantics.
  iii. If there are no lib targets, we return an error - this indicates the crate only has non-lib targets.

With the new logic in place we can remove the existing code for determining the Crate name to pass forward to `CargoRustDocJson`, it was only used for the expected JSON file name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Resolves https://github.com/awslabs/cargo-check-external-types/issues/113
