### PR TITLE
Support configuration via Cargo.toml metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,15 @@ cargo +nightly check-external-types
 ```
 
 This will produce errors if any external types are used in a public API at all. That's not terribly useful
-on its own, so the tool can be given a config file to allow certain types. For example, we can allow
-any type in `bytes` with:
+on its own, so the tool can be given configuration in your crate's `Cargo.toml` to allow certain types. 
+For example, we can allow any type in `bytes` by adding this metadata to your crate's `Cargo.toml`:
+
+```toml
+[package.metadata.cargo_check_external_types]
+allowed_external_types = ["bytes::*"]
+```
+
+Or, if you'd prefer, you can create a separate configuration file with the content:
 
 ```toml
 allowed_external_types = [
@@ -63,6 +70,9 @@ run the command with:
 ```bash
 cargo +nightly check-external-types --config external-types.toml
 ```
+
+If both a `Cargo.toml` package metadata section and a `--config` flag are provided, the `--config` flag will be used
+instead of the package metadata.
 
 ### Caveats
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Deserializer};
 use std::fmt;
 use wildmatch::WildMatch;
 
-/// Struct reprepsentation of the TOML config files that specify which external types are allowed.
+/// Struct representation of the TOML config files that specify which external types are allowed.
 #[derive(Debug, Deserialize)]
 pub struct Config {
     /// Whether or not to allow types from `alloc`. Defaults to true.

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Deserializer};
 use std::fmt;
 use wildmatch::WildMatch;
 
-/// Struct representation of the TOML config files that specify which external types are allowed.
+/// Struct representation of the Cargo.toml metadata, or TOML config files, that specify which
+/// external types are allowed.
 #[derive(Debug, Deserialize)]
 pub struct Config {
     /// Whether or not to allow types from `alloc`. Defaults to true.

--- a/test-workspace/Cargo.toml
+++ b/test-workspace/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "external-lib",
     "test-crate",
     "test-crate-custom-lib-name",
+    "test-crate-metadata-config",
     "test-reexports-crate",
     "test-type-exported-from-hidden-module",
 ]

--- a/test-workspace/test-crate-metadata-config/Cargo.toml
+++ b/test-workspace/test-crate-metadata-config/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test-crate-metadata-config"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+external-lib = { path = "../external-lib" }
+
+[package.metadata.cargo_check_external_types]
+# We allow external_lib::SomeStruct, but not external_lib::SimpleNewType, and so expect findings
+# to be produced for that type.
+allowed_external_types = ["external_lib::SomeStruct"]

--- a/test-workspace/test-crate-metadata-config/src/lib.rs
+++ b/test-workspace/test-crate-metadata-config/src/lib.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#![feature(generic_associated_types)]
+#![allow(dead_code)]
+
+//! This crate is used to test cargo-check-external-types against a crate that
+//! defines its configuration via metadata in its `Cargo.toml`. It only offers
+//! a subset of possible violations, see `test-crate` for a more complete example.
+
+use external_lib::{SimpleNewType, SomeStruct};
+
+pub static SOME_STRUCT: SomeStruct = SomeStruct;
+pub const SOME_CONST: SomeStruct = SomeStruct;
+
+pub mod some_pub_mod {
+    use external_lib::SomeStruct;
+
+    pub static OPTIONAL_STRUCT: Option<SomeStruct> = None;
+    pub const OPTIONAL_CONST: Option<SomeStruct> = None;
+}
+
+pub type NotExternalReferencing = u32;
+pub type ExternalReferencingTypeAlias = SomeStruct;
+pub type OptionalExternalReferencingTypeAlias = Option<SomeStruct>;
+pub type ExternalReferencingRawPtr = *const SomeStruct;
+
+pub struct AssocConstStruct;
+
+impl AssocConstStruct {
+    pub const SOME_CONST: u32 = 5;
+
+    pub const OTHER_CONST: SimpleNewType = SimpleNewType(5);
+}

--- a/tests/allow-some-types-metadata-expected-output.md
+++ b/tests/allow-some-types-metadata-expected-output.md
@@ -1,0 +1,9 @@
+error: Unapproved external type `external_lib::SimpleNewType` referenced in public API
+  --> test-crate-metadata-config/src/lib.rs:35:5
+   |
+35 |     pub const OTHER_CONST: SimpleNewType = SimpleNewType(5);
+   |     ^------------------------------------------------------^
+   |
+   = in struct field of `test_crate_metadata_config::AssocConstStruct::OTHER_CONST`
+
+1 errors, 0 warnings emitted

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -62,6 +62,29 @@ fn with_some_allowed_types() {
 }
 
 #[test]
+fn with_some_allowed_types_in_metadata() {
+    let expected_output =
+        fs::read_to_string("tests/allow-some-types-metadata-expected-output.md").unwrap();
+    let actual_output = run_with_args(
+        "test-workspace/test-crate-metadata-config",
+        &[], // We provide no config here so the crate's Cargo.toml metadata is used.
+    );
+    assert_str_eq!(expected_output, actual_output);
+}
+
+#[test]
+fn with_some_allowed_types_explicit_config_file() {
+    let actual_output = run_with_args(
+        "test-workspace/test-crate-metadata-config",
+        // Because we provide an explicit config file, we expect it to take precedence over
+        // the Cargo.toml metadata.
+        &["--config", "../../tests/allow-some-types.toml"],
+    );
+    // The config file allows all of the types, so we expect no output.
+    assert_str_eq!("", actual_output);
+}
+
+#[test]
 fn with_output_format_markdown_table() {
     let expected_output =
         fs::read_to_string("tests/output-format-markdown-table-expected-output.md").unwrap();


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/cargo-check-external-types/issues/48

*Description of changes:* Adding support for configuration via Cargo.toml metadata

Previously it was only possible to specify configuration (e.g. to allow certain types) via a separate TOML config file, provided via the `--config` CLI arg.

In this branch we add support for specifying the same config in the Crate's `Cargo.toml` in a metadata section like:

```toml
[package.metadata.cargo_check_external_types]
allow_alloc = true
allow_core = true
allow_std = true
allowed_external_types = ["foo*", "bar::BazStruct"]
```

When present in the `Cargo.toml` of the crate under test, this config will be used automatically. When omitted, the default config will be used.

If an explicit TOML config file is provided via `--config`, it will take precedence and override what may be found in the metadata.

A new integration test is added that demonstrates the metadata config in action, as well as the override behaviour with an explicit TOML config file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Resolves https://github.com/awslabs/cargo-check-external-types/issues/48
