### PR TITLE
Replace tracing_attributes::instrument with tracing::instrument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,6 @@ dependencies = [
  "test_bin",
  "toml",
  "tracing",
- "tracing-attributes",
  "tracing-subscriber",
  "wildmatch",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.7"
 tracing = "0.1"
-tracing-attributes = "0.1"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 wildmatch = "2"
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -16,8 +16,7 @@ use rustdoc_types::{
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Once;
-use tracing::{debug, warn};
-use tracing_attributes::instrument;
+use tracing::{debug, instrument, warn};
 
 macro_rules! unstable_rust_feature {
     ($name:expr, $documentation_uri:expr) => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`instrument` could be used via `tracing` crate instead of adding `tracing_attributes` as a dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
