### PR TITLE
Fix CI smoketest against Tokio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Run
         run: |
           cargo install --locked --path cargo-check-external-types
-          cargo check-external-types --all-features --config tokio/tokio/external-types.toml --manifest-path tokio/tokio/Cargo.toml
+          cargo check-external-types --all-features --manifest-path tokio/tokio/Cargo.toml
         env:
           # Intentionally don't set flags
           RUSTDOCFLAGS:


### PR DESCRIPTION
Tokio moved the external type config into the Cargo.toml file, so the argument specifying its location is no longer needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
