### PR TITLE
Bump rustdoc-types to v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
           cargo check-external-types --all-features --config aws-types/external-types.toml --manifest-path aws-types/Cargo.toml
         env:
           # Intentionally don't set flags
+          RUSTFLAGS:
           RUSTDOCFLAGS:
 
   smoketest-tokio:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_version: nightly-2023-10-10
+  rust_version: nightly-2024-02-07
 
 jobs:
   fmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc646f09069d689083b975698bdac4edb96c2f0e7d270b701760814b886bb224"
+checksum = "0904b9147011800e63763fb9e49bbeaf76c1b6ab8982824c659dce5433712559"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-check-external-types"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Static analysis tool to detect external types exposed in a library's public API."
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ cargo_metadata = "0.18"
 clap = { version = "4.4.18", features = ["derive"] }
 owo-colors = { version = "4", features = ["supports-colors"] }
 pest = "2" # For pretty error formatting
-rustdoc-types = "0.23.0"
+rustdoc-types = "0.24.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ How to Use
 
 _Important:_ This tool requires a nightly build of Rust to be installed since it relies on
 the [rustdoc JSON output](https://github.com/rust-lang/rust/issues/76578), which hasn't been
-stabilized yet. It was last tested against `nightly-2023-10-10`.
+stabilized yet. It was last tested against `nightly-2024-02-07`.
 
 To install, run the following from this README path:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-10-10"
+channel = "nightly-2024-02-07"

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -32,7 +32,7 @@ enum VisibilityCheck {
     /// Check to make sure the item is public before visiting it
     Default,
     /// Assume the item is public and examine it.
-    /// This is useful for visiting private items that are publically re-exported
+    /// This is useful for visiting private items that are publicly re-exported
     AssumePublic,
 }
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/cargo-check-external-types/issues/130

*Description of changes:*

- Bump rustdoc-types to v24 and,
- fix a typo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
