### PR TITLE
Bump rustdoc-types to v25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  rust_version: nightly-2024-02-07
+  rust_version: nightly-2024-05-01
 
 jobs:
   fmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-check-external-types"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -145,7 +145,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -319,18 +319,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -361,9 +361,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0904b9147011800e63763fb9e49bbeaf76c1b6ab8982824c659dce5433712559"
+checksum = "60966414633fced9e2341cd3d51a329d72306367325ba3d34e7e517c3bb84f3c"
 dependencies = [
  "serde",
 ]
@@ -385,22 +385,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -564,7 +564,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -614,9 +614,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-check-external-types"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Static analysis tool to detect external types exposed in a library's public API."
 edition = "2021"
@@ -13,7 +13,7 @@ cargo_metadata = "0.18"
 clap = { version = "4.4.18", features = ["derive"] }
 owo-colors = { version = "4", features = ["supports-colors"] }
 pest = "2" # For pretty error formatting
-rustdoc-types = "0.24.0"
+rustdoc-types = "0.25.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ How to Use
 
 _Important:_ This tool requires a nightly build of Rust to be installed since it relies on
 the [rustdoc JSON output](https://github.com/rust-lang/rust/issues/76578), which hasn't been
-stabilized yet. It was last tested against `nightly-2024-02-07`.
+stabilized yet. It was last tested against `nightly-2024-05-01`.
 
 To install, run the following from this README path:
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-02-07"
+channel = "nightly-2024-05-01"

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -402,6 +402,12 @@ impl Visitor {
             }
             Type::Generic(_) => {}
             Type::Primitive(_) => {}
+            Type::Pat { .. } => {
+                panic!(
+                    "Pattern types are unstable and rustc internal rust-lang#120131. \
+                     They are unsuported by cargo-check-external-types."
+                )
+            }
             Type::FunctionPointer(fp) => {
                 self.visit_fn_decl(path, &fp.decl)?;
                 self.visit_generic_param_defs(path, &fp.generic_params)?;


### PR DESCRIPTION
When using `cargo-check-external-types` with the latest nightly release I saw:

```
The version of rustdoc being used produces JSON format version 29, but this tool requires format version 28. This can happen if the locally installed version of rustdoc doesn't match the rustdoc JSON types from the `rustdoc-types` crate.

If this occurs with the latest Rust nightly and the latest version of this tool, then this is a bug, and the tool needs to be upgraded to the latest format version.

Otherwise, you'll need to determine a Rust nightly version that matches this tool's supported format version (or vice versa).
```

This change adds support for the most recent nightly versions using rustdoc format version 29.

The changelog for `rustdoc-types` can be found here https://github.com/aDotInTheVoid/rustdoc-types/blob/trunk/CHANGELOG.md#v0250---2024-04-19

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
