### PR TITLE
Do not report WherePredicate::BoundPredicate::type_

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -560,12 +560,13 @@ impl Visitor {
         for where_pred in &generics.where_predicates {
             match where_pred {
                 WherePredicate::BoundPredicate {
-                    type_,
+                    type_: _,
                     bounds,
                     generic_params,
                 } => {
-                    self.visit_type(path, &ErrorLocation::WhereBound, type_)
-                        .context(here!())?;
+                    // https://github.com/taiki-e/pin-project-lite/issues/86#issuecomment-2438300474
+                    // self.visit_type(path, &ErrorLocation::WhereBound, type_)
+                    //     .context(here!())?;
                     self.visit_generic_bounds(path, bounds)?;
                     self.visit_generic_param_defs(path, generic_params)?;
                 }


### PR DESCRIPTION
Fixes https://github.com/taiki-e/pin-project-lite/issues/86

*Description of changes:*

https://github.com/taiki-e/pin-project-lite/issues/86#issuecomment-2438300474

> In the first place, being triggered for a type that only appears in the where clause of the implementation block sounds like a bug in itself, regardless of whether it is doc(hidden) or not. (The types that appear at the bounds (traits and its associated types) need to be triggered, though.)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
