### PR TITLE
Unused deplicated

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::iter::Iterator;
 use std::path::{Path, PathBuf};
+use wildmatch::WildMatch;
 
 /// Where the error occurred relative to the [`Path`](crate::path::Path).
 ///
@@ -145,6 +146,17 @@ pub enum ValidationError {
         location: Option<Span>,
         sort_key: String,
     },
+    UnusedApprovalPattern {
+        type_name: String,
+    },
+    DuplicateApproved {
+        type_name: String,
+        what: ErrorLocation,
+        in_what_type: String,
+        location: Option<Span>,
+        duplicate: Vec<String>,
+        sort_key: String,
+    },
 }
 
 impl ValidationError {
@@ -175,9 +187,11 @@ impl ValidationError {
     pub fn level(&self) -> ErrorLevel {
         match self {
             Self::UnapprovedExternalTypeRef { .. } => ErrorLevel::Error,
-            Self::HiddenModule { .. } | Self::HiddenItem { .. } | Self::FieldsStripped { .. } => {
-                ErrorLevel::Warning
-            }
+            Self::HiddenModule { .. }
+            | Self::HiddenItem { .. }
+            | Self::FieldsStripped { .. }
+            | Self::UnusedApprovalPattern { .. }
+            | Self::DuplicateApproved { .. } => ErrorLevel::Warning,
         }
     }
 
@@ -222,11 +236,49 @@ impl ValidationError {
         }
     }
 
+    pub fn unused_approval_pattern(type_name: impl Into<String>) -> Self {
+        Self::UnusedApprovalPattern {
+            type_name: type_name.into(),
+        }
+    }
+
+    pub fn duplicate_approved(
+        type_name: impl Into<String>,
+        what: &ErrorLocation,
+        in_what_type: impl Into<String>,
+        location: Option<&Span>,
+        duplicate: Vec<&WildMatch>,
+    ) -> Self {
+        if location.is_none() {
+            bug!("A warning is missing a span and will be printed without context, file name, and line number.");
+        }
+        let type_name = type_name.into();
+        let in_what_type = in_what_type.into();
+        let duplicate = duplicate
+            .iter()
+            .map(|pattern| pattern.to_string())
+            .collect();
+        let sort_key = format!(
+            "{}:{type_name}:{what}:{in_what_type}",
+            location_sort_key(location)
+        );
+        Self::DuplicateApproved {
+            type_name,
+            what: what.clone(),
+            in_what_type,
+            location: location.cloned(),
+            duplicate,
+            sort_key: sort_key,
+        }
+    }
+
     pub fn type_name(&self) -> &str {
         match self {
             Self::UnapprovedExternalTypeRef { type_name, .. }
             | Self::HiddenModule { type_name, .. }
-            | Self::FieldsStripped { type_name } => type_name,
+            | Self::FieldsStripped { type_name }
+            | Self::UnusedApprovalPattern { type_name }
+            | Self::DuplicateApproved { type_name, .. } => type_name,
             Self::HiddenItem { .. } => "N/A",
         }
     }
@@ -235,17 +287,19 @@ impl ValidationError {
         match self {
             Self::UnapprovedExternalTypeRef { location, .. }
             | Self::HiddenModule { location, .. }
-            | Self::HiddenItem { location, .. } => location.as_ref(),
-            Self::FieldsStripped { .. } => None,
+            | Self::HiddenItem { location, .. }
+            | Self::DuplicateApproved { location, .. } => location.as_ref(),
+            Self::FieldsStripped { .. } | Self::UnusedApprovalPattern { .. } => None,
         }
     }
 
     fn sort_key(&self) -> &str {
         match self {
-            Self::UnapprovedExternalTypeRef { sort_key, .. } => sort_key.as_ref(),
-            Self::FieldsStripped { type_name } | Self::HiddenModule { type_name, .. } => {
-                type_name.as_ref()
-            }
+            Self::UnapprovedExternalTypeRef { sort_key, .. }
+            | Self::DuplicateApproved { sort_key, .. } => sort_key.as_ref(),
+            Self::FieldsStripped { type_name }
+            | Self::HiddenModule { type_name, .. }
+            | Self::UnusedApprovalPattern { type_name } => type_name.as_ref(),
             Self::HiddenItem { sort_key, .. } => sort_key.as_ref(),
         }
     }
@@ -265,22 +319,42 @@ impl ValidationError {
             } => {
                 let hidden_module = hidden_module.as_deref().unwrap_or("???");
                 write!(
-                    f,
-                    "Module path for reexported type `{type_name}` contains a `#[doc(hidden)]` module \"{hidden_module}\". Types declared in this module cannot be checked for external types"
-                )
+                     f,
+                     "Module path for reexported type `{type_name}` contains a `#[doc(hidden)]` module \"{hidden_module}\". Types declared in this module cannot be checked for external types"
+                 )
             }
             Self::HiddenItem {
                 what, in_what_type, ..
             } => {
                 write!(
-                    f,
-                    "{what} {in_what_type} references a hidden item. Items marked `#[doc(hidden)]` cannot be checked for external types"
-                )
+                     f,
+                     "{what} {in_what_type} references a hidden item. Items marked `#[doc(hidden)]` cannot be checked for external types"
+                 )
             }
             Self::FieldsStripped { type_name } => {
                 write!(
+                     f,
+                     "Fields on `{type_name}` marked `#[doc(hidden)]` cannot be checked for external types"
+                 )
+            }
+            Self::UnusedApprovalPattern { type_name } => {
+                write!(
                     f,
-                    "Fields on `{type_name}` marked `#[doc(hidden)]` cannot be checked for external types"
+                    "Approved external type `{type_name}` wasn't referenced in public API"
+                )
+            }
+            Self::DuplicateApproved {
+                type_name,
+                duplicate,
+                ..
+            } => {
+                write!(
+                    f,
+                    "External type `{type_name}` is allowed multiple times:\n Allowed patterns:{}",
+                    duplicate
+                        .iter()
+                        .map(|glob| format!("\n    - {}", glob))
+                        .fold(String::new(), |acc, f| acc + &f)
                 )
             }
         }
@@ -291,11 +365,14 @@ impl ValidationError {
             Self::UnapprovedExternalTypeRef {
                 what, in_what_type, ..
             } => format!("in {} `{}`", what, in_what_type).into(),
-            Self::FieldsStripped { .. } => "".into(),
+            Self::FieldsStripped { .. } | Self::UnusedApprovalPattern { .. } => "".into(),
             Self::HiddenModule {
                 what, in_what_type, ..
             }
             | Self::HiddenItem {
+                what, in_what_type, ..
+            }
+            | Self::DuplicateApproved {
                 what, in_what_type, ..
             } => format!("in {} `{}`", what, in_what_type).into(),
         }

--- a/tests/allow-types-multiple-times.md
+++ b/tests/allow-types-multiple-times.md
@@ -1,0 +1,141 @@
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:37:1
+   |
+37 | pub fn external_in_fn_input(_one: &SomeStruct, _two: impl SimpleTrait) {}
+   | ^-----------------------------------------------------------------------^
+   |
+   = in argument named `_two` of `test_crate::external_in_fn_input`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:37:1
+   |
+37 | pub fn external_in_fn_input(_one: &SomeStruct, _two: impl SimpleTrait) {}
+   | ^-----------------------------------------------------------------------^
+   |
+   = in trait bound of `test_crate::external_in_fn_input`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:46:1
+   |
+46 | pub fn external_opaque_type_in_output() -> impl SimpleTrait {
+   | ...
+48 | }␊
+   | ^
+   |
+   = in return value of `test_crate::external_opaque_type_in_output`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:88:27
+   |
+88 |     TupleEnum(SomeStruct, Box<dyn SimpleTrait>),
+   |                           ^------------------^
+   |
+   = in dyn trait of `test_crate::EnumWithExternals::TupleEnum::1`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:91:9
+   |
+91 |         simple_trait: Box<dyn SimpleTrait>,
+   |         ^--------------------------------^
+   |
+   = in dyn trait of `test_crate::EnumWithExternals::StructEnum::simple_trait`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:103:5
+    |
+103 |     pub fn another_thing<S: SimpleTrait>(_s: S) -> Self {
+    | ...
+105 |     }␊
+    |     ^
+    |
+    = in trait bound of `test_crate::EnumWithExternals::another_thing`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:121:1
+    |
+121 | pub type DynExternalReferencingTypeAlias = Box<dyn SimpleTrait>;
+    | ^--------------------------------------------------------------^
+    |
+    = in dyn trait of `test_crate::DynExternalReferencingTypeAlias`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:134:5
+    |
+134 |     type Thing: SimpleTrait;
+    |     ^----------------------^
+    |
+    = in trait bound of `test_crate::SomeTraitWithExternalDefaultTypes::Thing`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:145:5
+    |
+145 |     type MyGAT<T>
+    | ...
+147 |         T: SimpleTrait;␊
+    |     ^-----------------^
+    |
+    = in trait bound of `test_crate::SomeTraitWithGenericAssociatedType::MyGAT`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:149:5
+    |
+149 |     fn some_fn<T: SimpleTrait>(&self, thing: Self::MyGAT<T>);
+    |     ^-------------------------------------------------------^
+    |
+    = in trait bound of `test_crate::SomeTraitWithGenericAssociatedType::some_fn`
+
+warning: argument named `arg0` of test_crate::hidden_arg references a hidden item. Items marked `#[doc(hidden)]` cannot be checked for external types
+   --> test-crate/src/lib.rs:160:1
+    |
+160 | pub fn hidden_arg(arg0: HiddenStruct) {
+    | ...
+162 | }␊
+    | ^
+    |
+    = in argument named `arg0` of `test_crate::hidden_arg`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/test_union.rs:21:1
+   |
+21 | pub union GenericUnion<T: Copy + SimpleTrait> {
+   | ...
+24 | }␊
+   | ^
+   |
+   = in trait bound of `test_crate::test_union::GenericUnion`
+
+warning: Fields on `test_crate::test_fields_stripped::SomeStructWithStrippedFields` marked `#[doc(hidden)]` cannot be checked for external types
+0 errors, 13 warnings emitted

--- a/tests/allow-types-multiple-times.toml
+++ b/tests/allow-types-multiple-times.toml
@@ -1,0 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+allowed_external_types = ["external_lib::*", "external_lib::SimpleTrait"]

--- a/tests/allow-types-unused.md
+++ b/tests/allow-types-unused.md
@@ -1,0 +1,13 @@
+warning: Approved external type `external_lib::T*` wasn't referenced in public API
+warning: argument named `arg0` of test_crate::hidden_arg references a hidden item. Items marked `#[doc(hidden)]` cannot be checked for external types
+   --> test-crate/src/lib.rs:160:1
+    |
+160 | pub fn hidden_arg(arg0: HiddenStruct) {
+    | ...
+162 | }␊
+    | ^
+    |
+    = in argument named `arg0` of `test_crate::hidden_arg`
+
+warning: Fields on `test_crate::test_fields_stripped::SomeStructWithStrippedFields` marked `#[doc(hidden)]` cannot be checked for external types
+0 errors, 3 warnings emitted

--- a/tests/allow-types-unused.toml
+++ b/tests/allow-types-unused.toml
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+allowed_external_types = [
+    "external_lib::S*",
+    "external_lib::R*",
+    "external_lib::A*",
+
+    # Unused Pattern
+    "external_lib::T*",
+]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -95,6 +95,26 @@ fn with_output_format_markdown_table() {
     assert_str_eq!(expected_output, actual_output);
 }
 
+#[test]
+fn test_unused_allowed_external_types() {
+    let expected_output = fs::read_to_string("tests/allow-types-unused.md").unwrap();
+    let actual_output = run_with_args(
+        "test-workspace/test-crate",
+        &["--config", "../../tests/allow-types-unused.toml"],
+    );
+    assert_str_eq!(expected_output, actual_output);
+}
+
+#[test]
+fn test_multiple_allowed_external_types() {
+    let expected_output = fs::read_to_string("tests/allow-types-multiple-times.md").unwrap();
+    let actual_output = run_with_args(
+        "test-workspace/test-crate",
+        &["--config", "../../tests/allow-types-multiple-times.toml"],
+    );
+    assert_str_eq!(expected_output, actual_output);
+}
+
 // Make sure that the visitor doesn't attempt to visit the inner items of re-exported external types.
 // Rustdoc doesn't include these inner items in its JSON output, which leads to obtuse crashes if they're
 // referenced. It's also just the wrong behavior to look into the type being re-exported, since if it's


### PR DESCRIPTION
*Issue #, if available:*#17 

*Description of changes:* 
This PR adds functionality to:

1. Warn about unused approval patterns in allowed_external_types.
2. Warn about duplicated approval patterns that match the same type.

For example:
```rust
pub use foo::bar;
```
```toml
allowed_external_types = ["foo::*", "foo::bar"]
```  
Here, `foo::bar matches both` `"foo::*"` and `"foo::bar"`. However, only `"foo::*"` is necessary. With this PR, a warning is issued when multiple patterns match the same type. This helps in reducing redundant definitions in configuration.

Additionally, a warning is also issued for patterns in `allowed_external_types` that do not match any type in the public API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
