### PR TITLE
Warn About Unused and Duplicated Patterns in allowed_external_types

### DIFF
--- a/tests/allow-types-multiple-times.md
+++ b/tests/allow-types-multiple-times.md
@@ -1,0 +1,141 @@
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:37:1
+   |
+37 | pub fn external_in_fn_input(_one: &SomeStruct, _two: impl SimpleTrait) {}
+   | ^-----------------------------------------------------------------------^
+   |
+   = in argument named `_two` of `test_crate::external_in_fn_input`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:37:1
+   |
+37 | pub fn external_in_fn_input(_one: &SomeStruct, _two: impl SimpleTrait) {}
+   | ^-----------------------------------------------------------------------^
+   |
+   = in trait bound of `test_crate::external_in_fn_input`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:46:1
+   |
+46 | pub fn external_opaque_type_in_output() -> impl SimpleTrait {
+   | ...
+48 | }␊
+   | ^
+   |
+   = in return value of `test_crate::external_opaque_type_in_output`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:88:27
+   |
+88 |     TupleEnum(SomeStruct, Box<dyn SimpleTrait>),
+   |                           ^------------------^
+   |
+   = in dyn trait of `test_crate::EnumWithExternals::TupleEnum::1`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/lib.rs:91:9
+   |
+91 |         simple_trait: Box<dyn SimpleTrait>,
+   |         ^--------------------------------^
+   |
+   = in dyn trait of `test_crate::EnumWithExternals::StructEnum::simple_trait`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:103:5
+    |
+103 |     pub fn another_thing<S: SimpleTrait>(_s: S) -> Self {
+    | ...
+105 |     }␊
+    |     ^
+    |
+    = in trait bound of `test_crate::EnumWithExternals::another_thing`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:121:1
+    |
+121 | pub type DynExternalReferencingTypeAlias = Box<dyn SimpleTrait>;
+    | ^--------------------------------------------------------------^
+    |
+    = in dyn trait of `test_crate::DynExternalReferencingTypeAlias`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:134:5
+    |
+134 |     type Thing: SimpleTrait;
+    |     ^----------------------^
+    |
+    = in trait bound of `test_crate::SomeTraitWithExternalDefaultTypes::Thing`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:145:5
+    |
+145 |     type MyGAT<T>
+    | ...
+147 |         T: SimpleTrait;␊
+    |     ^-----------------^
+    |
+    = in trait bound of `test_crate::SomeTraitWithGenericAssociatedType::MyGAT`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+   --> test-crate/src/lib.rs:149:5
+    |
+149 |     fn some_fn<T: SimpleTrait>(&self, thing: Self::MyGAT<T>);
+    |     ^-------------------------------------------------------^
+    |
+    = in trait bound of `test_crate::SomeTraitWithGenericAssociatedType::some_fn`
+
+warning: argument named `arg0` of test_crate::hidden_arg references a hidden item. Items marked `#[doc(hidden)]` cannot be checked for external types
+   --> test-crate/src/lib.rs:160:1
+    |
+160 | pub fn hidden_arg(arg0: HiddenStruct) {
+    | ...
+162 | }␊
+    | ^
+    |
+    = in argument named `arg0` of `test_crate::hidden_arg`
+
+warning: External type `external_lib::SimpleTrait` is allowed multiple times:
+ Allowed patterns:
+    - external_lib::*
+    - external_lib::SimpleTrait
+  --> test-crate/src/test_union.rs:21:1
+   |
+21 | pub union GenericUnion<T: Copy + SimpleTrait> {
+   | ...
+24 | }␊
+   | ^
+   |
+   = in trait bound of `test_crate::test_union::GenericUnion`
+
+warning: Fields on `test_crate::test_fields_stripped::SomeStructWithStrippedFields` marked `#[doc(hidden)]` cannot be checked for external types
+0 errors, 13 warnings emitted

--- a/tests/allow-types-multiple-times.toml
+++ b/tests/allow-types-multiple-times.toml
@@ -1,0 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+allowed_external_types = ["external_lib::*", "external_lib::SimpleTrait"]

--- a/tests/allow-types-unused.md
+++ b/tests/allow-types-unused.md
@@ -1,0 +1,13 @@
+warning: Approved external type `external_lib::T*` wasn't referenced in public API
+warning: argument named `arg0` of test_crate::hidden_arg references a hidden item. Items marked `#[doc(hidden)]` cannot be checked for external types
+   --> test-crate/src/lib.rs:160:1
+    |
+160 | pub fn hidden_arg(arg0: HiddenStruct) {
+    | ...
+162 | }␊
+    | ^
+    |
+    = in argument named `arg0` of `test_crate::hidden_arg`
+
+warning: Fields on `test_crate::test_fields_stripped::SomeStructWithStrippedFields` marked `#[doc(hidden)]` cannot be checked for external types
+0 errors, 3 warnings emitted

--- a/tests/allow-types-unused.toml
+++ b/tests/allow-types-unused.toml
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+allowed_external_types = [
+    "external_lib::S*",
+    "external_lib::R*",
+    "external_lib::A*",
+
+    # Unused Pattern
+    "external_lib::T*",
+]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -95,6 +95,26 @@ fn with_output_format_markdown_table() {
     assert_str_eq!(expected_output, actual_output);
 }
 
+#[test]
+fn test_unused_allowed_external_types() {
+    let expected_output = fs::read_to_string("tests/allow-types-unused.md").unwrap();
+    let actual_output = run_with_args(
+        "test-workspace/test-crate",
+        &["--config", "../../tests/allow-types-unused.toml"],
+    );
+    assert_str_eq!(expected_output, actual_output);
+}
+
+#[test]
+fn test_multiple_allowed_external_types() {
+    let expected_output = fs::read_to_string("tests/allow-types-multiple-times.md").unwrap();
+    let actual_output = run_with_args(
+        "test-workspace/test-crate",
+        &["--config", "../../tests/allow-types-multiple-times.toml"],
+    );
+    assert_str_eq!(expected_output, actual_output);
+}
+
 // Make sure that the visitor doesn't attempt to visit the inner items of re-exported external types.
 // Rustdoc doesn't include these inner items in its JSON output, which leads to obtuse crashes if they're
 // referenced. It's also just the wrong behavior to look into the type being re-exported, since if it's


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/cargo-check-external-types/issues/17

*Description of changes:*
This PR adds functionality to:

1.    Warn about unused approval patterns in allowed_external_types.
2.   Warn about duplicated approval patterns that match the same type.

For example:
```rust
pub use foo::bar;
```
```toml
allowed_external_types = ["foo::*", "foo::bar"]
```
Here, `foo::bar` matches both `"foo::*"` and `"foo::bar"`. However, only `"foo::*"` is necessary. With this PR, a warning is issued when multiple patterns match the same type. This helps in reducing redundant definitions in configuration.

Additionally, a warning is also issued for patterns in `allowed_external_types` that do not match any type in the public API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
