### PR TITLE
bump release version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-check-external-types"
-version = "0.1.14"
+version = "0.2.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Static analysis tool to detect external types exposed in a library's public API."
 edition = "2021"


### PR DESCRIPTION
Bump release version to `0.2.0`. We've historically been releasing upgrades to min rust nightly as patch releases but unless there is a reason otherwise bumping minor seems more appropriate.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
